### PR TITLE
Small angular fix

### DIFF
--- a/openspending/static/js/app.js
+++ b/openspending/static/js/app.js
@@ -98,7 +98,7 @@ openspending.factory('referenceData', ['$http', function($http) {
 
 
 openspending.controller('DatasetNewCtrl', ['$scope', '$http', '$window', 'referenceData', 'validation',
-  function($scope, $http, $window, referenceData) {
+  function($scope, $http, $window, referenceData, validation) {
   /* This controller is not activated via routing, but explicitly through the 
   dataset.new flask route. */
   


### PR DESCRIPTION
Is this angular app intending to have page loads as the user navigates?  A stateprovider might be more appropriate?  Just a random thought.  

```
.config(function config( $stateProvider ) {
  $stateProvider.state( 'datamanager', {
    url: '/datamanager',
    views: {
      "main": {
        controller: 'DatamanagerCrl',
        templateUrl: 'datamanager/datamanager.tpl.html'
      }
    },
    data:{ pageTitle: 'Data Manager' }
  })
```

change with 

```
$location.path('/datamanger');
```